### PR TITLE
Update folding@home for newer version (not yet V8)

### DIFF
--- a/foldingathome/egg-folding--home.json
+++ b/foldingathome/egg-folding--home.json
@@ -4,14 +4,14 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2024-06-02T14:40:59+00:00",
+    "exported_at": "2024-09-08T19:48:06+02:00",
     "name": "Folding@Home",
     "author": "fuggschen@krk-gaming.de",
     "uuid": "6ac374df-1959-4d5e-a9c9-971c8c3f0b8f",
     "description": "Folding@home is a distributed computing project aimed to help scientists develop new therapeutics for a variety of diseases by the means of simulating protein dynamics. This includes the process of protein folding and the movements of proteins, and is reliant on simulations run on volunteers' personal computers",
-    "features": null,
+    "features": [],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:debian": "ghcr.io\/parkervcp\/yolks:debian"
+        "Debian": "ghcr.io\/parkervcp\/yolks:debian"
     },
     "file_denylist": [],
     "startup": ".\/FAHClient --user={{FAH_USERNAME}} --team={{FAH_TEAM}} --passkey={{FAH_PASSKEY}} $(if {{FAH_ANON}}; then echo \"--fold-anon=true\"; fi) --command-port={{SERVER_PORT}} --password={{FAH_PASSWORD}} --power={{FAH_POWER}}",
@@ -23,13 +23,14 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n#\r\n# Folding@Home install script\r\n#\r\n# Created by Fuggschen\r\n\r\nexport DEBIAN_FRONTEND=noninteractive\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] && echo \"64bit\" || echo \"arm64\")\r\ncd \/tmp\r\n\r\necho \"Removing previous Version\"\r\nmv \/mnt\/server\/config.xml \/tmp\/config.xml\r\nrm -rf \/mnt\/server\/*\r\n\r\necho \"Installing dependencies\"\r\napt update && apt upgrade -y && apt install curl bzip2 -y\r\n\r\necho \"Downloading FAHClient\"\r\ncurl -sSL -o fahclient.tar.bz2 https:\/\/download.foldingathome.org\/releases\/public\/release\/fahclient\/debian-stable-${ARCH}\/${FAH_VERSION}\/latest.tar.bz2\r\n\r\necho \"Installing FAHClient\"\r\ntar -xjf fahclient.tar.bz2 -C \/mnt\/server --strip-components=1\r\n\r\necho \"Cleaning up..\"\r\nrm -f fahclient.tar.bz2\r\nrm -f \/mnt\/server\/sample-config.xml\r\nmv \/tmp\/config.xml \/mnt\/server\/config.xml\r\n\r\nFILE=\/mnt\/server\/config.xml\r\nif [[ ! -f  $FILE ]]\r\nthen\r\necho \"Setting up config.xml\"\r\ncat > $FILE << EOF\r\n<config>\r\n  <!-- Folding Slots -->\r\n  <slot id='0' type='CPU'\/>\r\n  <!-- Maximum CPU Cores to use. Can't be more than 64 -->\r\n  <cpus v='64'\/>\r\n<\/config>\r\nEOF\r\nfi\r\n\r\necho \"Done!\"",
+            "script": "#!\/bin\/bash\r\n#\r\n# Folding@Home install script\r\n#\r\n# Created by Fuggschen\r\n\r\nexport DEBIAN_FRONTEND=noninteractive\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] && echo \"64bit\" || echo \"arm64\")\r\ncd \/tmp\r\n\r\necho \"Removing previous Version\"\r\nmv \/mnt\/server\/config.xml \/tmp\/config.xml\r\nrm -rf \/mnt\/server\/*\r\n\r\necho \"Installing dependencies\"\r\napt update && apt upgrade -y && apt install curl bzip2 -y\r\n\r\necho \"Downloading FAHClient\"\r\ncurl -sSL -o fahclient.tar.bz2 https:\/\/download.foldingathome.org\/releases\/v7\/public\/fahclient\/debian-stable-${ARCH}\/release\/fahclient_${FAH_VERSION}-64bit-release.tar.bz2\r\n\r\necho \"Installing FAHClient\"\r\ntar -xjf fahclient.tar.bz2 -C \/mnt\/server --strip-components=1\r\n\r\necho \"Cleaning up..\"\r\nrm -f fahclient.tar.bz2\r\nrm -f \/mnt\/server\/sample-config.xml\r\nmv \/tmp\/config.xml \/mnt\/server\/config.xml\r\n\r\nFILE=\/mnt\/server\/config.xml\r\nif [[ ! -f  $FILE ]]\r\nthen\r\necho \"Setting up config.xml\"\r\ncat > $FILE << EOF\r\n<config>\r\n  <!-- Folding Slots -->\r\n  <slot id='0' type='CPU'\/>\r\n  <!-- Maximum CPU Cores to use. Can't be more than 64 -->\r\n  <cpus v='64'\/>\r\n<\/config>\r\nEOF\r\nfi\r\n\r\necho \"Done!\"",
             "container": "ghcr.io\/parkervcp\/installers:debian",
             "entrypoint": "bash"
         }
     },
     "variables": [
         {
+            "sort": 1,
             "name": "FaH Username",
             "description": "Your Folding@Home Username",
             "env_variable": "FAH_USERNAME",
@@ -37,10 +38,10 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string",
-            "sort": null,
             "field_type": "text"
         },
         {
+            "sort": 2,
             "name": "FaH Team",
             "description": "Your Folding@Home Team that you are folding for. For reference look here: https:\/\/stats.foldingathome.org\/team",
             "env_variable": "FAH_TEAM",
@@ -48,10 +49,10 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|int",
-            "sort": null,
             "field_type": "text"
         },
         {
+            "sort": 3,
             "name": "FaH Passkey",
             "description": "Your Folding@Home Passkey for your Username, if not Anonymous. Get your Passkey here: https:\/\/apps.foldingathome.org\/getpasskey",
             "env_variable": "FAH_PASSKEY",
@@ -59,10 +60,10 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "nullable|string|max:32",
-            "sort": null,
             "field_type": "text"
         },
         {
+            "sort": 4,
             "name": "FaH Anonymous Mode",
             "description": "Set to true if you are folding Anonymously",
             "env_variable": "FAH_ANON",
@@ -70,21 +71,21 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|in:true,false",
-            "sort": null,
             "field_type": "text"
         },
         {
+            "sort": 5,
             "name": "FaH Version",
-            "description": "Set to wanted major Folding@Home Version. Check here: https:\/\/download.foldingathome.org\/releases\/public\/release\/fahclient\/debian-stable-64bit\/",
+            "description": "Set to wanted major Folding@Home Version. Check here: https:\/\/download.foldingathome.org\/releases\/v7\/public\/fahclient\/debian-stable-64bit\/release\/",
             "env_variable": "FAH_VERSION",
-            "default_value": "v7.6",
+            "default_value": "7.6.21",
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|max:20",
-            "sort": null,
             "field_type": "text"
         },
         {
+            "sort": 6,
             "name": "FaHControl Password",
             "description": "Set a WebUI Password",
             "env_variable": "FAH_PASSWORD",
@@ -92,10 +93,10 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|max:64",
-            "sort": null,
             "field_type": "text"
         },
         {
+            "sort": 7,
             "name": "FaH Power",
             "description": "The Powerlevel it should use:\r\n- light (only half the cpu power is used)\r\n- medium (full cpu power)\r\n- full (full cpu and gpu power but gpu is not supported)",
             "env_variable": "FAH_POWER",
@@ -103,7 +104,6 @@
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|in:light,medium,full",
-            "sort": null,
             "field_type": "text"
         }
     ]

--- a/foldingathome/egg-pterodactyl-folding--home.json
+++ b/foldingathome/egg-pterodactyl-folding--home.json
@@ -1,30 +1,30 @@
 {
-    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
+    "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "update_url": null,
-        "version": "PTDL_v2"
+        "version": "PTDL_v2",
+        "update_url": null
     },
-    "exported_at": "2024-06-02T14:40:59+00:00",
+    "exported_at": "2024-07-08T22:36:16+00:00",
     "name": "Folding@Home",
     "author": "fuggschen@krk-gaming.de",
     "description": "Folding@home is a distributed computing project aimed to help scientists develop new therapeutics for a variety of diseases by the means of simulating protein dynamics. This includes the process of protein folding and the movements of proteins, and is reliant on simulations run on volunteers' personal computers",
     "features": null,
     "docker_images": {
-        "ghcr.io/parkervcp/yolks:debian": "ghcr.io/parkervcp/yolks:debian"
+        "ghcr.io\/parkervcp\/yolks:debian": "ghcr.io\/parkervcp\/yolks:debian"
     },
     "file_denylist": [],
-    "startup": "./FAHClient --user={{FAH_USERNAME}} --team={{FAH_TEAM}} --passkey={{FAH_PASSKEY}} $(if {{FAH_ANON}}; then echo \"--fold-anon=true\"; fi) --command-port={{SERVER_PORT}} --password={{FAH_PASSWORD}} --power={{FAH_POWER}}",
+    "startup": ".\/FAHClient --user={{FAH_USERNAME}} --team={{FAH_TEAM}} --passkey={{FAH_PASSKEY}} $(if {{FAH_ANON}}; then echo \"--fold-anon=true\"; fi) --command-port={{SERVER_PORT}} --password={{FAH_PASSWORD}} --power={{FAH_POWER}}",
     "config": {
         "files": "{}",
-        "logs": "{}",
         "startup": "{\r\n    \"done\": \"Started FahCore\"\r\n}",
+        "logs": "{}",
         "stop": "^^C"
     },
     "scripts": {
         "installation": {
-            "container": "ghcr.io/parkervcp/installers:debian",
-            "entrypoint": "bash",
-            "script": "#!/bin/bash\r\n#\r\n# Folding@Home install script\r\n#\r\n# Created by Fuggschen\r\n\r\nexport DEBIAN_FRONTEND=noninteractive\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] \u0026\u0026 echo \"64bit\" || echo \"arm64\")\r\ncd /tmp\r\n\r\necho \"Removing previous Version\"\r\nmv /mnt/server/config.xml /tmp/config.xml\r\nrm -rf /mnt/server/*\r\n\r\necho \"Installing dependencies\"\r\napt update \u0026\u0026 apt upgrade -y \u0026\u0026 apt install curl bzip2 -y\r\n\r\necho \"Downloading FAHClient\"\r\ncurl -sSL -o fahclient.tar.bz2 https://download.foldingathome.org/releases/v7/public/fahclient/debian-stable-${ARCH}/release/fahclient_${FAH_VERSION}-${ARCH}-release.tar.bz2\r\n\r\necho \"Installing FAHClient\"\r\ntar -xjf fahclient.tar.bz2 -C /mnt/server --strip-components=1\r\n\r\necho \"Cleaning up..\"\r\nrm -f fahclient.tar.bz2\r\nrm -f /mnt/server/sample-config.xml\r\nmv /tmp/config.xml /mnt/server/config.xml\r\n\r\nFILE=/mnt/server/config.xml\r\nif [[ ! -f  $FILE ]]\r\nthen\r\necho \"Setting up config.xml\"\r\ncat \u003e $FILE \u003c\u003c EOF\r\n\u003cconfig\u003e\r\n  \u003c!-- Folding Slots --\u003e\r\n  \u003cslot id='0' type='CPU'/\u003e\r\n  \u003c!-- Maximum CPU Cores to use. Can't be more than 64 --\u003e\r\n  \u003ccpus v='64'/\u003e\r\n\u003c/config\u003e\r\nEOF\r\nfi\r\n\r\necho \"Done!\""
+            "script": "#!\/bin\/bash\r\n#\r\n# Folding@Home install script\r\n#\r\n# Created by Fuggschen\r\n\r\nexport DEBIAN_FRONTEND=noninteractive\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] && echo \"64bit\" || echo \"arm64\")\r\ncd \/tmp\r\n\r\necho \"Removing previous Version\"\r\nmv \/mnt\/server\/config.xml \/tmp\/config.xml\r\nrm -rf \/mnt\/server\/*\r\n\r\necho \"Installing dependencies\"\r\napt update && apt upgrade -y && apt install curl bzip2 -y\r\n\r\necho \"Downloading FAHClient\"\r\ncurl -sSL -o fahclient.tar.bz2 https:\/\/download.foldingathome.org\/releases\/v7\/public\/fahclient\/debian-stable-${ARCH}\/release\/fahclient_${FAH_VERSION}-${ARCH}-release.tar.bz2\r\n\r\necho \"Installing FAHClient\"\r\ntar -xjf fahclient.tar.bz2 -C \/mnt\/server --strip-components=1\r\n\r\necho \"Cleaning up..\"\r\nrm -f fahclient.tar.bz2\r\nrm -f \/mnt\/server\/sample-config.xml\r\nmv \/tmp\/config.xml \/mnt\/server\/config.xml\r\n\r\nFILE=\/mnt\/server\/config.xml\r\nif [[ ! -f  $FILE ]]\r\nthen\r\necho \"Setting up config.xml\"\r\ncat > $FILE << EOF\r\n<config>\r\n  <!-- Folding Slots -->\r\n  <slot id='0' type='CPU'\/>\r\n  <!-- Maximum CPU Cores to use. Can't be more than 64 -->\r\n  <cpus v='64'\/>\r\n<\/config>\r\nEOF\r\nfi\r\n\r\necho \"Done!\"",
+            "container": "ghcr.io\/parkervcp\/installers:debian",
+            "entrypoint": "bash"
         }
     },
     "variables": [
@@ -40,7 +40,7 @@
         },
         {
             "name": "FaH Team",
-            "description": "Your Folding@Home Team that you are folding for. For reference look here: https://stats.foldingathome.org/team",
+            "description": "Your Folding@Home Team that you are folding for. For reference look here: https:\/\/stats.foldingathome.org\/team",
             "env_variable": "FAH_TEAM",
             "default_value": "0",
             "user_viewable": true,
@@ -50,7 +50,7 @@
         },
         {
             "name": "FaH Passkey",
-            "description": "Your Folding@Home Passkey for your Username, if not Anonymous. Get your Passkey here: https://apps.foldingathome.org/getpasskey",
+            "description": "Your Folding@Home Passkey for your Username, if not Anonymous. Get your Passkey here: https:\/\/apps.foldingathome.org\/getpasskey",
             "env_variable": "FAH_PASSKEY",
             "default_value": "",
             "user_viewable": true,
@@ -70,9 +70,9 @@
         },
         {
             "name": "FaH Version",
-            "description": "Set to wanted major Folding@Home Version. Check here: https://download.foldingathome.org/releases/v7/public/fahclient/debian-stable-64bit/release/",
+            "description": "Set to wanted major Folding@Home Version. Check here: https:\/\/download.foldingathome.org\/releases\/v7\/public\/fahclient\/debian-stable-64bit\/release\/",
             "env_variable": "FAH_VERSION",
-            "default_value": "v7.6",
+            "default_value": "7.6.9",
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|max:20",

--- a/foldingathome/egg-pterodactyl-folding--home.json
+++ b/foldingathome/egg-pterodactyl-folding--home.json
@@ -4,13 +4,13 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2024-07-08T22:36:16+00:00",
+    "exported_at": "2024-09-08T19:48:06+02:00",
     "name": "Folding@Home",
     "author": "fuggschen@krk-gaming.de",
     "description": "Folding@home is a distributed computing project aimed to help scientists develop new therapeutics for a variety of diseases by the means of simulating protein dynamics. This includes the process of protein folding and the movements of proteins, and is reliant on simulations run on volunteers' personal computers",
-    "features": null,
+    "features": [],
     "docker_images": {
-        "ghcr.io\/parkervcp\/yolks:debian": "ghcr.io\/parkervcp\/yolks:debian"
+        "Debian": "ghcr.io\/parkervcp\/yolks:debian"
     },
     "file_denylist": [],
     "startup": ".\/FAHClient --user={{FAH_USERNAME}} --team={{FAH_TEAM}} --passkey={{FAH_PASSKEY}} $(if {{FAH_ANON}}; then echo \"--fold-anon=true\"; fi) --command-port={{SERVER_PORT}} --password={{FAH_PASSWORD}} --power={{FAH_POWER}}",
@@ -22,7 +22,7 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n#\r\n# Folding@Home install script\r\n#\r\n# Created by Fuggschen\r\n\r\nexport DEBIAN_FRONTEND=noninteractive\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] && echo \"64bit\" || echo \"arm64\")\r\ncd \/tmp\r\n\r\necho \"Removing previous Version\"\r\nmv \/mnt\/server\/config.xml \/tmp\/config.xml\r\nrm -rf \/mnt\/server\/*\r\n\r\necho \"Installing dependencies\"\r\napt update && apt upgrade -y && apt install curl bzip2 -y\r\n\r\necho \"Downloading FAHClient\"\r\ncurl -sSL -o fahclient.tar.bz2 https:\/\/download.foldingathome.org\/releases\/v7\/public\/fahclient\/debian-stable-${ARCH}\/release\/fahclient_${FAH_VERSION}-${ARCH}-release.tar.bz2\r\n\r\necho \"Installing FAHClient\"\r\ntar -xjf fahclient.tar.bz2 -C \/mnt\/server --strip-components=1\r\n\r\necho \"Cleaning up..\"\r\nrm -f fahclient.tar.bz2\r\nrm -f \/mnt\/server\/sample-config.xml\r\nmv \/tmp\/config.xml \/mnt\/server\/config.xml\r\n\r\nFILE=\/mnt\/server\/config.xml\r\nif [[ ! -f  $FILE ]]\r\nthen\r\necho \"Setting up config.xml\"\r\ncat > $FILE << EOF\r\n<config>\r\n  <!-- Folding Slots -->\r\n  <slot id='0' type='CPU'\/>\r\n  <!-- Maximum CPU Cores to use. Can't be more than 64 -->\r\n  <cpus v='64'\/>\r\n<\/config>\r\nEOF\r\nfi\r\n\r\necho \"Done!\"",
+            "script": "#!\/bin\/bash\r\n#\r\n# Folding@Home install script\r\n#\r\n# Created by Fuggschen\r\n\r\nexport DEBIAN_FRONTEND=noninteractive\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] && echo \"64bit\" || echo \"arm64\")\r\ncd \/tmp\r\n\r\necho \"Removing previous Version\"\r\nmv \/mnt\/server\/config.xml \/tmp\/config.xml\r\nrm -rf \/mnt\/server\/*\r\n\r\necho \"Installing dependencies\"\r\napt update && apt upgrade -y && apt install curl bzip2 -y\r\n\r\necho \"Downloading FAHClient\"\r\ncurl -sSL -o fahclient.tar.bz2 https:\/\/download.foldingathome.org\/releases\/v7\/public\/fahclient\/debian-stable-${ARCH}\/release\/fahclient_${FAH_VERSION}-64bit-release.tar.bz2\r\n\r\necho \"Installing FAHClient\"\r\ntar -xjf fahclient.tar.bz2 -C \/mnt\/server --strip-components=1\r\n\r\necho \"Cleaning up..\"\r\nrm -f fahclient.tar.bz2\r\nrm -f \/mnt\/server\/sample-config.xml\r\nmv \/tmp\/config.xml \/mnt\/server\/config.xml\r\n\r\nFILE=\/mnt\/server\/config.xml\r\nif [[ ! -f  $FILE ]]\r\nthen\r\necho \"Setting up config.xml\"\r\ncat > $FILE << EOF\r\n<config>\r\n  <!-- Folding Slots -->\r\n  <slot id='0' type='CPU'\/>\r\n  <!-- Maximum CPU Cores to use. Can't be more than 64 -->\r\n  <cpus v='64'\/>\r\n<\/config>\r\nEOF\r\nfi\r\n\r\necho \"Done!\"",
             "container": "ghcr.io\/parkervcp\/installers:debian",
             "entrypoint": "bash"
         }
@@ -72,7 +72,7 @@
             "name": "FaH Version",
             "description": "Set to wanted major Folding@Home Version. Check here: https:\/\/download.foldingathome.org\/releases\/v7\/public\/fahclient\/debian-stable-64bit\/release\/",
             "env_variable": "FAH_VERSION",
-            "default_value": "7.6.9",
+            "default_value": "7.6.21",
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|max:20",

--- a/foldingathome/egg-pterodactyl-folding--home.json
+++ b/foldingathome/egg-pterodactyl-folding--home.json
@@ -24,7 +24,7 @@
         "installation": {
             "container": "ghcr.io/parkervcp/installers:debian",
             "entrypoint": "bash",
-            "script": "#!/bin/bash\r\n#\r\n# Folding@Home install script\r\n#\r\n# Created by Fuggschen\r\n\r\nexport DEBIAN_FRONTEND=noninteractive\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] \u0026\u0026 echo \"64bit\" || echo \"arm64\")\r\ncd /tmp\r\n\r\necho \"Removing previous Version\"\r\nmv /mnt/server/config.xml /tmp/config.xml\r\nrm -rf /mnt/server/*\r\n\r\necho \"Installing dependencies\"\r\napt update \u0026\u0026 apt upgrade -y \u0026\u0026 apt install curl bzip2 -y\r\n\r\necho \"Downloading FAHClient\"\r\ncurl -sSL -o fahclient.tar.bz2 https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-${ARCH}/${FAH_VERSION}/latest.tar.bz2\r\n\r\necho \"Installing FAHClient\"\r\ntar -xjf fahclient.tar.bz2 -C /mnt/server --strip-components=1\r\n\r\necho \"Cleaning up..\"\r\nrm -f fahclient.tar.bz2\r\nrm -f /mnt/server/sample-config.xml\r\nmv /tmp/config.xml /mnt/server/config.xml\r\n\r\nFILE=/mnt/server/config.xml\r\nif [[ ! -f  $FILE ]]\r\nthen\r\necho \"Setting up config.xml\"\r\ncat \u003e $FILE \u003c\u003c EOF\r\n\u003cconfig\u003e\r\n  \u003c!-- Folding Slots --\u003e\r\n  \u003cslot id='0' type='CPU'/\u003e\r\n  \u003c!-- Maximum CPU Cores to use. Can't be more than 64 --\u003e\r\n  \u003ccpus v='64'/\u003e\r\n\u003c/config\u003e\r\nEOF\r\nfi\r\n\r\necho \"Done!\""
+            "script": "#!/bin/bash\r\n#\r\n# Folding@Home install script\r\n#\r\n# Created by Fuggschen\r\n\r\nexport DEBIAN_FRONTEND=noninteractive\r\nARCH=$([[ \"$(uname -m)\" == \"x86_64\" ]] \u0026\u0026 echo \"64bit\" || echo \"arm64\")\r\ncd /tmp\r\n\r\necho \"Removing previous Version\"\r\nmv /mnt/server/config.xml /tmp/config.xml\r\nrm -rf /mnt/server/*\r\n\r\necho \"Installing dependencies\"\r\napt update \u0026\u0026 apt upgrade -y \u0026\u0026 apt install curl bzip2 -y\r\n\r\necho \"Downloading FAHClient\"\r\ncurl -sSL -o fahclient.tar.bz2 https://download.foldingathome.org/releases/v7/public/fahclient/debian-stable-${ARCH}/release/fahclient_${FAH_VERSION}-${ARCH}-release.tar.bz2\r\n\r\necho \"Installing FAHClient\"\r\ntar -xjf fahclient.tar.bz2 -C /mnt/server --strip-components=1\r\n\r\necho \"Cleaning up..\"\r\nrm -f fahclient.tar.bz2\r\nrm -f /mnt/server/sample-config.xml\r\nmv /tmp/config.xml /mnt/server/config.xml\r\n\r\nFILE=/mnt/server/config.xml\r\nif [[ ! -f  $FILE ]]\r\nthen\r\necho \"Setting up config.xml\"\r\ncat \u003e $FILE \u003c\u003c EOF\r\n\u003cconfig\u003e\r\n  \u003c!-- Folding Slots --\u003e\r\n  \u003cslot id='0' type='CPU'/\u003e\r\n  \u003c!-- Maximum CPU Cores to use. Can't be more than 64 --\u003e\r\n  \u003ccpus v='64'/\u003e\r\n\u003c/config\u003e\r\nEOF\r\nfi\r\n\r\necho \"Done!\""
         }
     },
     "variables": [
@@ -70,7 +70,7 @@
         },
         {
             "name": "FaH Version",
-            "description": "Set to wanted major Folding@Home Version. Check here: https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/",
+            "description": "Set to wanted major Folding@Home Version. Check here: https://download.foldingathome.org/releases/v7/public/fahclient/debian-stable-64bit/release/",
             "env_variable": "FAH_VERSION",
             "default_value": "v7.6",
             "user_viewable": true,


### PR DESCRIPTION
# Description
The download link for the V7 version of the FAH Client has changed to a new location. I'm unable to rewrite this egg to be compatible with V8, but I should have successfully changed the download url to the current version. This version of the egg worked on my install.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [ ] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?: I'm not really used to working with Github PR's, so I sort of followed what Github says, and believe this might be the right way.

<!-- If this is an egg update fill these out -->

* [X] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [X] The egg was exported from the panel