### PR TITLE
Fixed: uptime-kuma auto-update not working

### DIFF
--- a/uptime-kuma/egg-uptime-kuma.json
+++ b/uptime-kuma/egg-uptime-kuma.json
@@ -7,7 +7,7 @@
     "exported_at": "2025-03-29T08:52:25+00:00",
     "name": "Uptime Kuma",
     "author": "eggs@goover.dev",
-    "uuid": "d4118190-8de0-4d10-a5e6-50407048517b",
+    "uuid": "e8dba66d-3cd3-4d5d-979c-dbecc0b1468f",
     "description": "Uptime Kuma is an easy-to-use self-hosted monitoring tool.",
     "features": [],
     "docker_images": {

--- a/uptime-kuma/egg-uptime-kuma.json
+++ b/uptime-kuma/egg-uptime-kuma.json
@@ -1,20 +1,20 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
-        "version": "PTDL_v2",
+        "version": "PLCN_v1",
         "update_url": null
     },
-    "exported_at": "2024-06-02T14:40:55+00:00",
+    "exported_at": "2025-03-29T07:50:08+00:00",
     "name": "Uptime Kuma",
     "author": "eggs@goover.dev",
-    "uuid": "e8dba66d-3cd3-4d5d-979c-dbecc0b1468f",
+    "uuid": "d4118190-8de0-4d10-a5e6-50407048517b",
     "description": "Uptime Kuma is an easy-to-use self-hosted monitoring tool.",
-    "features": null,
+    "features": [],
     "docker_images": {
         "ghcr.io\/parkervcp\/apps:uptimekuma": "ghcr.io\/parkervcp\/apps:uptimekuma"
     },
     "file_denylist": [],
-    "startup": "if [[ -d .git ]] && [[ {{AUTO_UPDATE}} == \"1\" ]]; then npm run setup; fi; \/usr\/local\/bin\/node \/home\/container\/server\/server.js --port={{SERVER_PORT}}",
+    "startup": "if [[ -d .git ]] && [[ {{AUTO_UPDATE}} == \"1\" ]]; then git fetch --all && git checkout 1.23.16 --force && npm install --production && npm run download-dist; fi; \/usr\/local\/bin\/node \/home\/container\/server\/server.js --port={{SERVER_PORT}}",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"[SERVER] INFO: Listening on \"\r\n}",
@@ -36,9 +36,11 @@
             "default_value": "https:\/\/github.com\/louislam\/uptime-kuma",
             "user_viewable": false,
             "user_editable": false,
-            "rules": "nullable|string",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "nullable",
+                "string"
+            ],
+            "sort": 1
         },
         {
             "name": "JS file",
@@ -47,9 +49,11 @@
             "default_value": "server\/server.js",
             "user_viewable": false,
             "user_editable": false,
-            "rules": "required|string",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "string"
+            ],
+            "sort": 2
         },
         {
             "name": "Auto Update",
@@ -58,9 +62,11 @@
             "default_value": "1",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|boolean",
-            "sort": null,
-            "field_type": "text"
+            "rules": [
+                "required",
+                "boolean"
+            ],
+            "sort": 3
         }
     ]
 }

--- a/uptime-kuma/egg-uptime-kuma.json
+++ b/uptime-kuma/egg-uptime-kuma.json
@@ -4,7 +4,7 @@
         "version": "PLCN_v1",
         "update_url": null
     },
-    "exported_at": "2025-03-29T07:50:08+00:00",
+    "exported_at": "2025-03-29T08:52:25+00:00",
     "name": "Uptime Kuma",
     "author": "eggs@goover.dev",
     "uuid": "d4118190-8de0-4d10-a5e6-50407048517b",
@@ -14,7 +14,7 @@
         "ghcr.io\/parkervcp\/apps:uptimekuma": "ghcr.io\/parkervcp\/apps:uptimekuma"
     },
     "file_denylist": [],
-    "startup": "if [[ -d .git ]] && [[ {{AUTO_UPDATE}} == \"1\" ]]; then git fetch --all && git checkout 1.23.16 --force && npm install --production && npm run download-dist; fi; \/usr\/local\/bin\/node \/home\/container\/server\/server.js --port={{SERVER_PORT}}",
+    "startup": "if [[ -d .git ]] && [[ {{AUTO_UPDATE}} == \"1\" ]]; then git fetch --all && git checkout {{PATHSPEC}} --force && npm install --production && npm run download-dist; fi; \/usr\/local\/bin\/node \/home\/container\/server\/server.js --port={{SERVER_PORT}}",
     "config": {
         "files": "{}",
         "startup": "{\r\n    \"done\": \"[SERVER] INFO: Listening on \"\r\n}",
@@ -67,6 +67,16 @@
                 "boolean"
             ],
             "sort": 3
+        },
+        {
+            "name": "pathspec",
+            "description": "",
+            "env_variable": "PATHSPEC",
+            "default_value": "1.23.16",
+            "user_viewable": false,
+            "user_editable": false,
+            "rules": [],
+            "sort": 4
         }
     ]
 }


### PR DESCRIPTION
The start command has been changed so that Kuma is updated when auto-update is set to 1

# Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [ ] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel

<!-- You can erase the new egg submission template if you're not adding a completely new egg -->

## New egg Submissions

1. [x] Does your submission pass tests (server is connectable)?
2. [ ] Does your egg use a custom docker image?
    * [ ] Have you tried to use a generic image?
    * [ ] Did you PR the necessary changes to make it work?
3. [ ] Have you added the egg to the main README.md and any other README files in subdirectories of the egg (e.g /game_eggs) according to the alphabetical order?
4. [ ] Have you added a unique README.md for the egg you are adding according to the alphabetical order?
5. [x] You verify that the start command applied does not use a shell script
    * [ ] If some script is needed then it is part of a current yolk or a PR to add one
6. [x] The egg was exported from the panel